### PR TITLE
Make DefautQtr the EndQtr

### DIFF
--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -21,14 +21,16 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
+  const defaultQuarter = quarters[quarters.length - 1].yyyyq;
+
   const localSearchQuarter = localStorage.getItem(controlId);
   if (!localSearchQuarter) {
-    localStorage.setItem(controlId, quarters[0].yyyyq);
+    localStorage.setItem(controlId, defaultQuarter);
   }
 
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    quarter.yyyq || localSearchQuarter || quarters[0].yyyyq,
+    quarter.yyyq || localSearchQuarter || defaultQuarter,
   );
 
   const handleQuarterOnChange = (event) => {

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -146,7 +146,7 @@ describe("SingleQuarterSelector tests", () => {
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("20201"));
+    await waitFor(() => expect(useState).toBeCalledWith("20224"));
   });
 
   test("when localstorage has no value, first element of quarter range is the default parameter", async () => {
@@ -165,7 +165,7 @@ describe("SingleQuarterSelector tests", () => {
     );
 
     await waitFor(() =>
-      expect(setQuarterStateSpy).toBeCalledWith("sqd1", "20201"),
+      expect(setQuarterStateSpy).toBeCalledWith("sqd1", "20224"),
     );
   });
 });


### PR DESCRIPTION
In this PR, added implementation so that the end quarter would be set as the default quarter for the home page search courses. When local storage cleared, defaults to END_QTR and keeps previous visit search.

Closes #25 