### PR TITLE
BUG: Modal for Adding Courses on Basic Course Search Page Displays All Schedules

### DIFF
--- a/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
+++ b/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
@@ -7,11 +7,9 @@ import { useBackend } from "main/utils/useBackend";
 import { Link } from "react-router-dom";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
-export default function AddToScheduleModal({ section, onAdd }) {
+export default function AddToScheduleModal({ quarter, section, onAdd }) {
   const [showModal, setShowModal] = useState(false);
   const [selectedSchedule, setSelectedSchedule] = useState("");
-
-  const localQuarter = localStorage.getItem("BasicSearch.Quarter");
 
   // Stryker disable all
   const {
@@ -37,7 +35,7 @@ export default function AddToScheduleModal({ section, onAdd }) {
 
   //filter schedules to match the current quarter 
   const filteredSchedules = schedules.filter(
-    (schedule) => schedule.quarter === localQuarter
+    (schedule) => schedule.quarter === quarter
   );
 
   // Stryker disable all : tested manually, complicated to test
@@ -65,7 +63,7 @@ export default function AddToScheduleModal({ section, onAdd }) {
                 </Form.Group>
               ) : (
                 <p>
-                  No personal schedules exist for quarter {yyyyqToQyy(localQuarter.toString())}.
+                  No personal schedules exist for quarter {yyyyqToQyy(quarter)}.
                   <br />
                   <Link to="/personalschedules/create">[Create One]</Link>
                 </p>

--- a/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
+++ b/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
@@ -6,6 +6,7 @@ import PersonalScheduleSelector from "./PersonalScheduleSelector";
 import { useBackend } from "main/utils/useBackend";
 import { Link } from "react-router-dom";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+import { filterSchedulesByQuarter } from "main/utils/PersonalScheduleUtils";
 
 export default function AddToScheduleModal({ quarter, section, onAdd }) {
   const [showModal, setShowModal] = useState(false);
@@ -33,9 +34,8 @@ export default function AddToScheduleModal({ quarter, section, onAdd }) {
   };
 
   //filter schedules to match the current quarter
-  const filteredSchedules = schedules.filter(
-    (schedule) => schedule.quarter === quarter,
-  );
+
+  const filteredSchedules = filterSchedulesByQuarter(schedules, quarter);
 
   // Stryker disable all : tested manually, complicated to test
   return (

--- a/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
+++ b/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
@@ -19,7 +19,7 @@ export default function AddToScheduleModal({ quarter, section, onAdd }) {
   } = useBackend(
     ["/api/personalschedules/all"],
     { method: "GET", url: "/api/personalschedules/all" },
-    [],
+    []
   );
   // Stryker restore all
 
@@ -32,8 +32,7 @@ export default function AddToScheduleModal({ quarter, section, onAdd }) {
     handleModalClose();
   };
 
-
-  //filter schedules to match the current quarter 
+  //filter schedules to match the current quarter
   const filteredSchedules = schedules.filter(
     (schedule) => schedule.quarter === quarter
   );

--- a/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
+++ b/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
@@ -10,6 +10,25 @@ export default function AddToScheduleModal({ section, onAdd }) {
   const [showModal, setShowModal] = useState(false);
   const [selectedSchedule, setSelectedSchedule] = useState("");
 
+  const localQuarter = localStorage.getItem("BasicSearch.Quarter");
+
+  //translate quarter from yyyyq to qyy
+  var quarterTrans = "";
+  if (localQuarter.substring(4, 5) === "1") {
+    quarterTrans = "W";
+  }
+  else if (localQuarter.substring(4, 5) === "2") {
+    quarterTrans = "S"
+  }
+  if (localQuarter.substring(4, 5) === "1") {
+    quarterTrans = "M";
+  }
+  else {
+    quarterTrans = "F";
+  }
+
+  quarterTrans += localQuarter.substring(2, 4);
+
   // Stryker disable all
   const {
     data: schedules,
@@ -30,6 +49,13 @@ export default function AddToScheduleModal({ section, onAdd }) {
     onAdd(section, selectedSchedule);
     handleModalClose();
   };
+
+
+  //filter schedules to match the current quarter 
+  const filteredSchedules = schedules.filter(
+    (schedule) => schedule.quarter === localQuarter
+  );
+
   // Stryker disable all : tested manually, complicated to test
   return (
     <>
@@ -43,10 +69,11 @@ export default function AddToScheduleModal({ section, onAdd }) {
         <Modal.Body>
           <Form>
             {
-              /* istanbul ignore next */ schedules.length > 0 ? (
+              /* istanbul ignore next */ filteredSchedules.length > 0 ? (
                 <Form.Group controlId="scheduleSelect">
                   <Form.Label>Select Schedule</Form.Label>
                   <PersonalScheduleSelector
+                    filteredSchedules={filteredSchedules}
                     schedule={selectedSchedule}
                     setSchedule={setSelectedSchedule}
                     controlId="scheduleSelect"
@@ -54,8 +81,9 @@ export default function AddToScheduleModal({ section, onAdd }) {
                 </Form.Group>
               ) : (
                 <p>
-                  No schedules found.
-                  <Link to="/personalschedules/create">Create a schedule</Link>
+                  No personal schedules exist for quarter {quarterTrans}.
+                  <br />
+                  <Link to="/personalschedules/create">[Create One]</Link>
                 </p>
               )
             }

--- a/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
+++ b/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
@@ -5,29 +5,13 @@ import Form from "react-bootstrap/Form";
 import PersonalScheduleSelector from "./PersonalScheduleSelector";
 import { useBackend } from "main/utils/useBackend";
 import { Link } from "react-router-dom";
+import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
 export default function AddToScheduleModal({ section, onAdd }) {
   const [showModal, setShowModal] = useState(false);
   const [selectedSchedule, setSelectedSchedule] = useState("");
 
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
-
-  //translate quarter from yyyyq to qyy
-  var quarterTrans = "";
-  if (localQuarter.substring(4, 5) === "1") {
-    quarterTrans = "W";
-  }
-  else if (localQuarter.substring(4, 5) === "2") {
-    quarterTrans = "S"
-  }
-  if (localQuarter.substring(4, 5) === "1") {
-    quarterTrans = "M";
-  }
-  else {
-    quarterTrans = "F";
-  }
-
-  quarterTrans += localQuarter.substring(2, 4);
 
   // Stryker disable all
   const {
@@ -81,7 +65,7 @@ export default function AddToScheduleModal({ section, onAdd }) {
                 </Form.Group>
               ) : (
                 <p>
-                  No personal schedules exist for quarter {quarterTrans}.
+                  No personal schedules exist for quarter {yyyyqToQyy(localQuarter.toString())}.
                   <br />
                   <Link to="/personalschedules/create">[Create One]</Link>
                 </p>

--- a/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
+++ b/frontend/src/main/components/PersonalSchedules/AddToScheduleModal.js
@@ -19,7 +19,7 @@ export default function AddToScheduleModal({ quarter, section, onAdd }) {
   } = useBackend(
     ["/api/personalschedules/all"],
     { method: "GET", url: "/api/personalschedules/all" },
-    []
+    [],
   );
   // Stryker restore all
 
@@ -34,7 +34,7 @@ export default function AddToScheduleModal({ quarter, section, onAdd }) {
 
   //filter schedules to match the current quarter
   const filteredSchedules = schedules.filter(
-    (schedule) => schedule.quarter === quarter
+    (schedule) => schedule.quarter === quarter,
   );
 
   // Stryker disable all : tested manually, complicated to test

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleSelector.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleSelector.js
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { Form } from "react-bootstrap";
-import { useBackend } from "main/utils/useBackend";
+//import { useBackend } from "main/utils/useBackend";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
 const PersonalScheduleSelector = ({
+  filteredSchedules,
   schedule,
   setSchedule,
   controlId,
@@ -16,23 +17,11 @@ const PersonalScheduleSelector = ({
     localSearchSchedule || schedule,
   );
 
-  // Stryker disable all
-  const {
-    data: schedules,
-    error: _error,
-    status: _status,
-  } = useBackend(
-    ["/api/personalschedules/all"],
-    { method: "GET", url: "/api/personalschedules/all" },
-    [],
-  );
-  // Stryker restore all
-
   useEffect(() => {
-    if (schedules.length > 0) {
-      setSchedule(schedules[0].id);
+    if (filteredSchedules && filteredSchedules.length > 0) {
+      setSchedule(filteredSchedules[0].id);
     }
-  }, [schedules, setSchedule]);
+  }, [filteredSchedules, setSchedule]);
 
   const handleScheduleOnChange = (event) => {
     const selectedSchedule = event.target.value;
@@ -52,8 +41,8 @@ const PersonalScheduleSelector = ({
         value={scheduleState}
         onChange={handleScheduleOnChange}
       >
-        {schedules &&
-          schedules.map((schedule) => (
+        {filteredSchedules &&
+          filteredSchedules.map((schedule) => (
             <option key={schedule.id} value={schedule.id}>
               {yyyyqToQyy(schedule.quarter)} {schedule.name}
             </option>

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleSelector.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleSelector.js
@@ -11,10 +11,11 @@ const PersonalScheduleSelector = ({
   onChange = null,
   label = "Schedule",
 }) => {
-  const localSearchSchedule = localStorage.getItem(controlId);
+  //const localSearchSchedule = localStorage.getItem(controlId);
 
   const [scheduleState, setScheduleState] = useState(
-    localSearchSchedule || schedule,
+    schedule,
+    //localSearchSchedule || schedule,
   );
 
   useEffect(() => {

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleSelector.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleSelector.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import { Form } from "react-bootstrap";
-//import { useBackend } from "main/utils/useBackend";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
 const PersonalScheduleSelector = ({
@@ -11,12 +10,7 @@ const PersonalScheduleSelector = ({
   onChange = null,
   label = "Schedule",
 }) => {
-  //const localSearchSchedule = localStorage.getItem(controlId);
-
-  const [scheduleState, setScheduleState] = useState(
-    schedule,
-    //localSearchSchedule || schedule,
-  );
+  const [scheduleState, setScheduleState] = useState(schedule);
 
   useEffect(() => {
     if (filteredSchedules && filteredSchedules.length > 0) {

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -25,7 +25,7 @@ function getFirstVal(values) {
 export function isLectureWithNoSections(enrollCode, sections) {
   // Find the section with the given enrollCode
   const section = sections.find(
-    (section) => section.section.enrollCode === enrollCode,
+    (section) => section.section.enrollCode === enrollCode
   );
 
   if (section) {
@@ -38,7 +38,7 @@ export function isLectureWithNoSections(enrollCode, sections) {
       // Filter all sections with the same courseId
       // Stryker disable all
       const courseSections = sections.filter(
-        (section) => section.courseInfo.courseId === courseId,
+        (section) => section.courseInfo.courseId === courseId
       );
       // Stryker restore all
       // Check if there is only one section for the course
@@ -82,7 +82,7 @@ export const handleLectureAddToSchedule = (section, schedule, mutation) => {
 
 export const onSuccess = (response) => {
   toast(
-    `New course Created - id: ${response[0].id} enrollCd: ${response[0].enrollCd}`,
+    `New course Created - id: ${response[0].id} enrollCd: ${response[0].enrollCd}`
   );
 };
 
@@ -96,7 +96,7 @@ export default function SectionsTable({ sections }) {
     objectToAxiosParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    ["/api/courses/user/all"],
+    ["/api/courses/user/all"]
   );
 
   const columns = [
@@ -197,7 +197,7 @@ export default function SectionsTable({ sections }) {
             <div className="d-flex align-items-center gap-2">
               <span>{value}</span>
               <AddToScheduleModal
-                quarter = {original.courseInfo.quarter}
+                quarter={original.courseInfo.quarter}
                 section={original}
                 onAdd={(section, schedule) =>
                   handleAddToSchedule(section, schedule, mutation)
@@ -217,7 +217,7 @@ export default function SectionsTable({ sections }) {
             <div className="d-flex align-items-center gap-2">
               <span>{value}</span>
               <AddToScheduleModal
-                quarter = {sections[0].courseInfo.quarter}
+                quarter={sections[0].courseInfo.quarter}
                 section={value}
                 onAdd={(section, schedule) =>
                   handleLectureAddToSchedule(section, schedule, mutation)

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -197,6 +197,7 @@ export default function SectionsTable({ sections }) {
             <div className="d-flex align-items-center gap-2">
               <span>{value}</span>
               <AddToScheduleModal
+                quarter = {original.courseInfo.quarter}
                 section={original}
                 onAdd={(section, schedule) =>
                   handleAddToSchedule(section, schedule, mutation)
@@ -216,6 +217,7 @@ export default function SectionsTable({ sections }) {
             <div className="d-flex align-items-center gap-2">
               <span>{value}</span>
               <AddToScheduleModal
+                quarter = {sections[0].courseInfo.quarter}
                 section={value}
                 onAdd={(section, schedule) =>
                   handleLectureAddToSchedule(section, schedule, mutation)

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -25,7 +25,7 @@ function getFirstVal(values) {
 export function isLectureWithNoSections(enrollCode, sections) {
   // Find the section with the given enrollCode
   const section = sections.find(
-    (section) => section.section.enrollCode === enrollCode
+    (section) => section.section.enrollCode === enrollCode,
   );
 
   if (section) {
@@ -38,7 +38,7 @@ export function isLectureWithNoSections(enrollCode, sections) {
       // Filter all sections with the same courseId
       // Stryker disable all
       const courseSections = sections.filter(
-        (section) => section.courseInfo.courseId === courseId
+        (section) => section.courseInfo.courseId === courseId,
       );
       // Stryker restore all
       // Check if there is only one section for the course
@@ -82,7 +82,7 @@ export const handleLectureAddToSchedule = (section, schedule, mutation) => {
 
 export const onSuccess = (response) => {
   toast(
-    `New course Created - id: ${response[0].id} enrollCd: ${response[0].enrollCd}`
+    `New course Created - id: ${response[0].id} enrollCd: ${response[0].enrollCd}`,
   );
 };
 
@@ -96,7 +96,7 @@ export default function SectionsTable({ sections }) {
     objectToAxiosParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    ["/api/courses/user/all"]
+    ["/api/courses/user/all"],
   );
 
   const columns = [

--- a/frontend/src/main/utils/PersonalScheduleUtils.js
+++ b/frontend/src/main/utils/PersonalScheduleUtils.js
@@ -14,3 +14,7 @@ export function cellToAxiosParamsDelete(cell) {
     },
   };
 }
+
+export function filterSchedulesByQuarter(schedules, quarter) {
+  return schedules.filter((schedule) => schedule.quarter === quarter);
+}

--- a/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
@@ -78,30 +78,21 @@ describe("AddToScheduleModal", () => {
 
     fireEvent.click(screen.getByText("Add"));
 
-    expect(screen.getByText("No schedules found.")).toBeInTheDocument();
-    expect(screen.getByText("Create a schedule")).toHaveAttribute(
-      "href",
-      "/personalschedules/create",
-    );
-  });
+    // Define your quarter variable
+      const quarter = "F21";
 
-  test("displays correct message when no schedules found initially", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Router>
-          <AddToScheduleModal onAdd={mockOnAdd} section={null} />
-        </Router>
-      </QueryClientProvider>,
-    );
+      // Mock the localStorage.getItem function to return the quarter
+      global.localStorage.getItem = jest.fn(() => quarter);
 
-    fireEvent.click(screen.getByText("Add"));
+      // ...rest of your test setup...
 
-    expect(screen.getByText("No schedules found.")).toBeInTheDocument();
-    expect(screen.getByText("Create a schedule")).toHaveAttribute(
-      "href",
-      "/personalschedules/create",
-    );
-  });
+      // Use the quarter variable in your expect statement
+      expect(screen.getByText(`No schedules exist for ${quarter}.`)).toBeInTheDocument();    
+      expect(screen.getByText("[Create One]")).toHaveAttribute(
+          "href",
+          "/personalschedules/create",
+        );
+      });
 
   test("calls onAdd with the correct schedule when save is clicked", () => {
     render(
@@ -128,15 +119,6 @@ describe("AddToScheduleModal", () => {
     },
   );
 
-  test("displays correct message when no schedules found on initial render", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Router>
-          <AddToScheduleModal onAdd={mockOnAdd} section={null} />
-        </Router>
-      </QueryClientProvider>,
-    );
-
     fireEvent.click(screen.getByText("Add"));
 
     expect(screen.getByText("No schedules found.")).toBeInTheDocument();
@@ -145,4 +127,3 @@ describe("AddToScheduleModal", () => {
       "/personalschedules/create",
     );
   });
-});

--- a/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
@@ -9,27 +9,17 @@ const queryClient = new QueryClient();
 
 describe("AddToScheduleModal", () => {
   let mockOnAdd;
-  let getItemSpy;
+  const quarter = "20214";
 
   beforeEach(() => {
     mockOnAdd = jest.fn();
     // Define your localQuarter variable
-    const localQuarter = "F21";
-
-    // Mock localStorage.getItem
-    getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-    getItemSpy.mockReturnValue(localQuarter);
-  });
-
-  afterEach(() => {
-    // Clean up after each test
-    getItemSpy.mockRestore();
   });
 
   test("renders without crashing", () => {
     render(
       <QueryClientProvider client={queryClient}>
-        <AddToScheduleModal onAdd={mockOnAdd} />
+        <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
       </QueryClientProvider>,
     );
   });
@@ -38,7 +28,7 @@ describe("AddToScheduleModal", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Router>
-          <AddToScheduleModal onAdd={mockOnAdd} />
+          <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
       </QueryClientProvider>,
     );
@@ -58,7 +48,7 @@ describe("AddToScheduleModal", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Router>
-          <AddToScheduleModal onAdd={mockOnAdd} />
+          <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
       </QueryClientProvider>,
     );
@@ -83,21 +73,16 @@ describe("AddToScheduleModal", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Router>
-          <AddToScheduleModal onAdd={mockOnAdd} />
+          <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
       </QueryClientProvider>,
     );
 
     fireEvent.click(screen.getByText("Add"));
-
-      // Define your quarter variable
-      const quarter = "F21";
-
-      // Use the quarter variable in your expect statement
-      expect(screen.getByText(`No personal schedules exist for ${quarter}.`)).toBeInTheDocument();    
-      expect(screen.getByText("[Create One]")).toHaveAttribute(
-          "href",
-          "/personalschedules/create",
+    expect(screen.getByText("No personal schedules exist for quarter F21.")).toBeInTheDocument();    
+    expect(screen.getByText("[Create One]")).toHaveAttribute(
+        "href",
+        "/personalschedules/create",
     );
   });
 
@@ -105,7 +90,7 @@ describe("AddToScheduleModal", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Router>
-          <AddToScheduleModal onAdd={mockOnAdd} section={"Stryker was here!"} />
+          <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} section={"Stryker was here!"} />
         </Router>
       </QueryClientProvider>,
     );
@@ -115,14 +100,4 @@ describe("AddToScheduleModal", () => {
 
     expect(mockOnAdd).toHaveBeenCalledWith("Stryker was here!", "");
   });
-
-  jest.mock(
-    "main/components/PersonalSchedules/PersonalScheduleSelector",
-    () => {
-      return ({ setHasSchedules }) => {
-        setHasSchedules(false);
-        return null;
-      };
-    },
-  );
 });

--- a/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
@@ -9,9 +9,21 @@ const queryClient = new QueryClient();
 
 describe("AddToScheduleModal", () => {
   let mockOnAdd;
+  let getItemSpy;
 
   beforeEach(() => {
     mockOnAdd = jest.fn();
+    // Define your localQuarter variable
+    const localQuarter = "F21";
+
+    // Mock localStorage.getItem
+    getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+    getItemSpy.mockReturnValue(localQuarter);
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    getItemSpy.mockRestore();
   });
 
   test("renders without crashing", () => {
@@ -78,21 +90,16 @@ describe("AddToScheduleModal", () => {
 
     fireEvent.click(screen.getByText("Add"));
 
-    // Define your quarter variable
+      // Define your quarter variable
       const quarter = "F21";
 
-      // Mock the localStorage.getItem function to return the quarter
-      global.localStorage.getItem = jest.fn(() => quarter);
-
-      // ...rest of your test setup...
-
       // Use the quarter variable in your expect statement
-      expect(screen.getByText(`No schedules exist for ${quarter}.`)).toBeInTheDocument();    
+      expect(screen.getByText(`No personal schedules exist for ${quarter}.`)).toBeInTheDocument();    
       expect(screen.getByText("[Create One]")).toHaveAttribute(
           "href",
           "/personalschedules/create",
-        );
-      });
+    );
+  });
 
   test("calls onAdd with the correct schedule when save is clicked", () => {
     render(
@@ -118,12 +125,4 @@ describe("AddToScheduleModal", () => {
       };
     },
   );
-
-    fireEvent.click(screen.getByText("Add"));
-
-    expect(screen.getByText("No schedules found.")).toBeInTheDocument();
-    expect(screen.getByText("Create a schedule")).toHaveAttribute(
-      "href",
-      "/personalschedules/create",
-    );
-  });
+});

--- a/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
@@ -20,7 +20,7 @@ describe("AddToScheduleModal", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
   });
 
@@ -30,7 +30,7 @@ describe("AddToScheduleModal", () => {
         <Router>
           <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     fireEvent.click(screen.getByText("Add"));
@@ -50,7 +50,7 @@ describe("AddToScheduleModal", () => {
         <Router>
           <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     fireEvent.click(screen.getByText("Add"));
@@ -66,7 +66,7 @@ describe("AddToScheduleModal", () => {
         setHasSchedules(false);
         return null;
       };
-    }
+    },
   );
 
   test("displays correct message when no schedules found", () => {
@@ -75,16 +75,16 @@ describe("AddToScheduleModal", () => {
         <Router>
           <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     fireEvent.click(screen.getByText("Add"));
     expect(
-      screen.getByText("No personal schedules exist for quarter F21.")
+      screen.getByText("No personal schedules exist for quarter F21."),
     ).toBeInTheDocument();
     expect(screen.getByText("[Create One]")).toHaveAttribute(
       "href",
-      "/personalschedules/create"
+      "/personalschedules/create",
     );
   });
 
@@ -98,7 +98,7 @@ describe("AddToScheduleModal", () => {
             section={"Stryker was here!"}
           />
         </Router>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     fireEvent.click(screen.getByText("Add"));

--- a/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/AddToScheduleModal.test.js
@@ -20,7 +20,7 @@ describe("AddToScheduleModal", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
   });
 
@@ -30,7 +30,7 @@ describe("AddToScheduleModal", () => {
         <Router>
           <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     fireEvent.click(screen.getByText("Add"));
@@ -50,7 +50,7 @@ describe("AddToScheduleModal", () => {
         <Router>
           <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     fireEvent.click(screen.getByText("Add"));
@@ -66,7 +66,7 @@ describe("AddToScheduleModal", () => {
         setHasSchedules(false);
         return null;
       };
-    },
+    }
   );
 
   test("displays correct message when no schedules found", () => {
@@ -75,14 +75,16 @@ describe("AddToScheduleModal", () => {
         <Router>
           <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} />
         </Router>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     fireEvent.click(screen.getByText("Add"));
-    expect(screen.getByText("No personal schedules exist for quarter F21.")).toBeInTheDocument();    
+    expect(
+      screen.getByText("No personal schedules exist for quarter F21.")
+    ).toBeInTheDocument();
     expect(screen.getByText("[Create One]")).toHaveAttribute(
-        "href",
-        "/personalschedules/create",
+      "href",
+      "/personalschedules/create"
     );
   });
 
@@ -90,9 +92,13 @@ describe("AddToScheduleModal", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Router>
-          <AddToScheduleModal quarter={quarter} onAdd={mockOnAdd} section={"Stryker was here!"} />
+          <AddToScheduleModal
+            quarter={quarter}
+            onAdd={mockOnAdd}
+            section={"Stryker was here!"}
+          />
         </Router>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     fireEvent.click(screen.getByText("Add"));

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleSelector.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleSelector.test.js
@@ -8,56 +8,43 @@ jest.mock("main/utils/useBackend");
 jest.mock("main/utils/quarterUtilities.js");
 
 describe("PersonalScheduleSelector", () => {
+  const filteredSchedules = [
+    { id: "schedule1", quarter: "20221", name: "Schedule 1" },
+    { id: "schedule2", quarter: "20222", name: "Schedule 2" },
+  ];
+
+  const emptyFilteredSchedules = [];
+
   beforeEach(() => {
-    localStorage.clear();
-    /*useBackend.mockReturnValue({
-      data: [
-        { id: "schedule1", quarter: "20221", name: "Schedule 1" },
-        { id: "schedule2", quarter: "20222", name: "Schedule 2" },
-      ],
-      error: null,
-      status: "success",
-    });*/
-    const quarter = "F21";
-
-    global.localStorage.getItem = jest.fn(() => quarter);
-    yyyyqToQyy.mockReturnValue("Q1 2022");
+    yyyyqToQyy.mockReturnValue("F22");
   });
 
-  test("sets the initial schedule from local storage if match", () => {
-    localStorage.setItem("controlId", "schedule2");
+  test("sets the initial schedule from the filtered schedule prop if matching quarters", () => {
     render(
-      <PersonalScheduleSelector controlId="controlId" setSchedule={() => {}} />,
+      
+      <PersonalScheduleSelector 
+      filteredSchedules={filteredSchedules}
+      schedule="schedule1" 
+      setSchedule={() => {}} 
+      />,
     );
-    expect(screen.getByDisplayValue("Q1 2022 Schedule 2")).toBeInTheDocument();
-  });
-
-  test("sets the initial schedule from the schedule prop", () => {
-    render(
-      <PersonalScheduleSelector schedule="schedule1" setSchedule={() => {}} />,
-    );
-    expect(screen.getByDisplayValue("Q1 2022 Schedule 1")).toBeInTheDocument();
-  });
-
-  test("calls setSchedule with the first schedule when schedules are loaded", () => {
-    const setSchedule = jest.fn();
-    render(<PersonalScheduleSelector setSchedule={setSchedule} />);
-    expect(setSchedule).toHaveBeenCalledWith("schedule1");
+    expect(screen.getByDisplayValue("F22 Schedule 1")).toBeInTheDocument();
   });
 
   test("updates the schedule state and calls setSchedule when a schedule is selected", () => {
     const setSchedule = jest.fn();
     render(
       <PersonalScheduleSelector
+        filteredSchedules={filteredSchedules}
         controlId="controlId"
         setSchedule={setSchedule}
       />,
     );
     fireEvent.change(screen.getByLabelText("Schedule"), {
-      target: { value: "schedule2" },
+      target: { value: "schedule1" },
     });
-    expect(localStorage.getItem("controlId")).toBe("schedule2");
-    expect(setSchedule).toHaveBeenCalledWith("schedule2");
+    expect(localStorage.getItem("controlId")).toBe("schedule1");
+    expect(setSchedule).toHaveBeenCalledWith("schedule1");
   });
 
   test("updates the schedule state, calls setSchedule, and calls onChange when a schedule is selected", () => {
@@ -65,6 +52,7 @@ describe("PersonalScheduleSelector", () => {
     const onChange = jest.fn();
     render(
       <PersonalScheduleSelector
+        filteredSchedules={filteredSchedules}
         controlId="controlId"
         setSchedule={setSchedule}
         onChange={onChange}
@@ -73,10 +61,10 @@ describe("PersonalScheduleSelector", () => {
     const selectElement = screen.getByLabelText("Schedule", {
       selector: "select",
     });
-    fireEvent.change(selectElement, { target: { value: "schedule2" } });
+    fireEvent.change(selectElement, { target: { value: "schedule1" } });
 
-    expect(localStorage.getItem("controlId")).toBe("schedule2");
-    expect(setSchedule).toHaveBeenCalledWith("schedule2");
+    expect(localStorage.getItem("controlId")).toBe("schedule1");
+    expect(setSchedule).toHaveBeenCalledWith("schedule1");
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(expect.any(Object)); // Event object
   });
@@ -84,33 +72,20 @@ describe("PersonalScheduleSelector", () => {
   test("sets the initial schedule when schedules are loaded", () => {
     const setSchedule = jest.fn();
 
-    // Mock the useBackend hook to return an empty schedules array initially
-    useBackend.mockReturnValueOnce({
-      data: [],
-      error: null,
-      status: "success",
-    });
-
     // Render the component with an empty schedules array
     const { rerender } = render(
-      <PersonalScheduleSelector setSchedule={`setSchedule`} />,
+      <PersonalScheduleSelector 
+      filteredSchedules={emptyFilteredSchedules}
+      setSchedule={`setSchedule`} />,
     );
 
     // Assert that setSchedule is not called when schedules array is empty
     expect(setSchedule).not.toHaveBeenCalled();
 
-    // Mock the useBackend hook to return a non-empty schedules array
-    useBackend.mockReturnValueOnce({
-      data: [
-        { id: "schedule1", quarter: "20221", name: "Schedule 1" },
-        { id: "schedule2", quarter: "20222", name: "Schedule 2" },
-      ],
-      error: null,
-      status: "success",
-    });
-
     // Rerender the component with the updated schedules array
-    rerender(<PersonalScheduleSelector setSchedule={setSchedule} />);
+    rerender(<PersonalScheduleSelector 
+      filteredSchedules={filteredSchedules}
+      setSchedule={setSchedule} />);
 
     // Assert that setSchedule is called with the first schedule id when schedules array is not empty
     expect(setSchedule).toHaveBeenCalledWith("schedule1");

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleSelector.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleSelector.test.js
@@ -23,7 +23,7 @@ describe("PersonalScheduleSelector", () => {
         filteredSchedules={filteredSchedules}
         schedule="schedule1"
         setSchedule={() => {}}
-      />
+      />,
     );
     expect(screen.getByDisplayValue("F22 Schedule 1")).toBeInTheDocument();
   });
@@ -35,7 +35,7 @@ describe("PersonalScheduleSelector", () => {
         filteredSchedules={filteredSchedules}
         controlId="controlId"
         setSchedule={setSchedule}
-      />
+      />,
     );
     fireEvent.change(screen.getByLabelText("Schedule"), {
       target: { value: "schedule1" },
@@ -53,7 +53,7 @@ describe("PersonalScheduleSelector", () => {
         controlId="controlId"
         setSchedule={setSchedule}
         onChange={onChange}
-      />
+      />,
     );
     const selectElement = screen.getByLabelText("Schedule", {
       selector: "select",
@@ -74,7 +74,7 @@ describe("PersonalScheduleSelector", () => {
       <PersonalScheduleSelector
         filteredSchedules={emptyFilteredSchedules}
         setSchedule={`setSchedule`}
-      />
+      />,
     );
 
     // Assert that setSchedule is not called when schedules array is empty
@@ -85,7 +85,7 @@ describe("PersonalScheduleSelector", () => {
       <PersonalScheduleSelector
         filteredSchedules={filteredSchedules}
         setSchedule={setSchedule}
-      />
+      />,
     );
 
     // Assert that setSchedule is called with the first schedule id when schedules array is not empty

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleSelector.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleSelector.test.js
@@ -10,18 +10,21 @@ jest.mock("main/utils/quarterUtilities.js");
 describe("PersonalScheduleSelector", () => {
   beforeEach(() => {
     localStorage.clear();
-    useBackend.mockReturnValue({
+    /*useBackend.mockReturnValue({
       data: [
         { id: "schedule1", quarter: "20221", name: "Schedule 1" },
         { id: "schedule2", quarter: "20222", name: "Schedule 2" },
       ],
       error: null,
       status: "success",
-    });
+    });*/
+    const quarter = "F21";
+
+    global.localStorage.getItem = jest.fn(() => quarter);
     yyyyqToQyy.mockReturnValue("Q1 2022");
   });
 
-  test("sets the initial schedule from local storage", () => {
+  test("sets the initial schedule from local storage if match", () => {
     localStorage.setItem("controlId", "schedule2");
     render(
       <PersonalScheduleSelector controlId="controlId" setSchedule={() => {}} />,

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleSelector.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleSelector.test.js
@@ -1,10 +1,8 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import PersonalScheduleSelector from "main/components/PersonalSchedules/PersonalScheduleSelector";
-import { useBackend } from "main/utils/useBackend";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
-jest.mock("main/utils/useBackend");
 jest.mock("main/utils/quarterUtilities.js");
 
 describe("PersonalScheduleSelector", () => {
@@ -21,12 +19,11 @@ describe("PersonalScheduleSelector", () => {
 
   test("sets the initial schedule from the filtered schedule prop if matching quarters", () => {
     render(
-      
-      <PersonalScheduleSelector 
-      filteredSchedules={filteredSchedules}
-      schedule="schedule1" 
-      setSchedule={() => {}} 
-      />,
+      <PersonalScheduleSelector
+        filteredSchedules={filteredSchedules}
+        schedule="schedule1"
+        setSchedule={() => {}}
+      />
     );
     expect(screen.getByDisplayValue("F22 Schedule 1")).toBeInTheDocument();
   });
@@ -38,7 +35,7 @@ describe("PersonalScheduleSelector", () => {
         filteredSchedules={filteredSchedules}
         controlId="controlId"
         setSchedule={setSchedule}
-      />,
+      />
     );
     fireEvent.change(screen.getByLabelText("Schedule"), {
       target: { value: "schedule1" },
@@ -56,7 +53,7 @@ describe("PersonalScheduleSelector", () => {
         controlId="controlId"
         setSchedule={setSchedule}
         onChange={onChange}
-      />,
+      />
     );
     const selectElement = screen.getByLabelText("Schedule", {
       selector: "select",
@@ -74,18 +71,22 @@ describe("PersonalScheduleSelector", () => {
 
     // Render the component with an empty schedules array
     const { rerender } = render(
-      <PersonalScheduleSelector 
-      filteredSchedules={emptyFilteredSchedules}
-      setSchedule={`setSchedule`} />,
+      <PersonalScheduleSelector
+        filteredSchedules={emptyFilteredSchedules}
+        setSchedule={`setSchedule`}
+      />
     );
 
     // Assert that setSchedule is not called when schedules array is empty
     expect(setSchedule).not.toHaveBeenCalled();
 
     // Rerender the component with the updated schedules array
-    rerender(<PersonalScheduleSelector 
-      filteredSchedules={filteredSchedules}
-      setSchedule={setSchedule} />);
+    rerender(
+      <PersonalScheduleSelector
+        filteredSchedules={filteredSchedules}
+        setSchedule={setSchedule}
+      />
+    );
 
     // Assert that setSchedule is called with the first schedule id when schedules array is not empty
     expect(setSchedule).toHaveBeenCalledWith("schedule1");

--- a/frontend/src/tests/utils/PersonalScheduleUtils.test.js
+++ b/frontend/src/tests/utils/PersonalScheduleUtils.test.js
@@ -1,6 +1,7 @@
 import {
   onDeleteSuccess,
   cellToAxiosParamsDelete,
+  filterSchedulesByQuarter,
 } from "main/utils/PersonalScheduleUtils";
 import mockConsole from "jest-mock-console";
 
@@ -46,6 +47,21 @@ describe("PersonalScheduleUtils", () => {
         method: "DELETE",
         params: { id: 17 },
       });
+    });
+  });
+
+  describe("filterSchedulesByQuarter", () => {
+    test("It filters schedules by quarter", () => {
+      // arrange
+      const schedules = [
+        { id: 1, quarter: "20221", name: "Schedule 1" },
+        { id: 2, quarter: "20222", name: "Schedule 2" },
+      ];
+
+      //assert
+      expect(filterSchedulesByQuarter(schedules, "20221")).toEqual([
+        { id: 1, quarter: "20221", name: "Schedule 1" },
+      ]);
     });
   });
 });


### PR DESCRIPTION
- fixed the bug so that the modal only displays schedules for the corresponding quarter
- when no schedules match, displays a message saying no schedules exist for the quarter the user is searching on and link to create a new schedule

dokku: [https://al-proj-courses.dokku-04.cs.ucsb.edu](url)
Closes #1 