### PR TITLE
Added Improvement Course History Search Feature 

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -56,6 +56,7 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
   );
   const [courseNumber, setCourseNumber] = useState(localCourseNumber || "");
   const [courseSuf, setCourseSuf] = useState("");
+  const [coursePre, setCoursePre] = useState("");
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -65,6 +66,7 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
       subject,
       courseNumber,
       courseSuf,
+      coursePre,
     });
   };
 
@@ -77,12 +79,20 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
       setCourseNumber("");
     }
 
-    if (rawCourse.match(/[a-zA-Z]+/g) != null) {
-      const suffix = rawCourse.match(/[a-zA-Z]+/g)[0];
+    if (rawCourse.match(/[a-zA-Z]+$/g) != null) {
+      const suffix = rawCourse.match(/[a-zA-Z]+$/g)[0];
       setCourseSuf(suffix);
     } else {
       setCourseSuf("");
     }
+
+    if (rawCourse.match(/^[a-zA-z]+/g) != null) {
+      const prefix = rawCourse.match(/^[a-zA-z]+/g)[0];
+      setCoursePre(prefix);
+    } else {
+      setCoursePre("");
+    }
+    
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeSearchForm.js
@@ -92,7 +92,6 @@ const CourseOverTimeSearchForm = ({ fetchJSON }) => {
     } else {
       setCoursePre("");
     }
-    
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeSearchForm.test.js
@@ -169,6 +169,7 @@ describe("CourseOverTimeSearchForm tests", () => {
       subject: "CMPSC",
       courseNumber: "130",
       courseSuf: "A",
+      coursePre: "CS",
     };
 
     const expectedKey = "CourseOverTimeSearch.Subject-option-CMPSC";
@@ -186,7 +187,7 @@ describe("CourseOverTimeSearchForm tests", () => {
     const selectCourseNumber = screen.getByLabelText(
       "Course Number (Try searching '16' or '130A')",
     );
-    userEvent.type(selectCourseNumber, "130A");
+    userEvent.type(selectCourseNumber, "CS130A");
     const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
 


### PR DESCRIPTION
In this PR, added feature that allowed for a search that had a prefix to give the same classes that didn't have a prefix. An example would be CS130A that gave the same output as a search of 130A or 130.

Closes #11 