### PR TITLE
Add Admin Job Frontend for Grade Data

### DIFF
--- a/frontend/src/main/components/Jobs/UploadGradeDataJobForm.js
+++ b/frontend/src/main/components/Jobs/UploadGradeDataJobForm.js
@@ -1,0 +1,33 @@
+import { Form, Button, Container, Row, Col } from "react-bootstrap";
+
+const UploadGradeDataJobForm = ({ callback }) => {
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    callback();
+  };
+
+  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
+  const padding = { paddingTop: 10, paddingBottom: 10 };
+  // Stryker restore all
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Container>
+        <Row style={padding}>
+          <Col md="auto">
+            <Button
+              variant="primary"
+              type="submit"
+              data-testid="uploadGradeData"
+            >
+              Update Grades
+            </Button>
+          </Col>
+        </Row>
+      </Container>
+    </Form>
+  );
+};
+
+export default UploadGradeDataJobForm;

--- a/frontend/src/main/components/Jobs/UploadGradeDataJobForm.js
+++ b/frontend/src/main/components/Jobs/UploadGradeDataJobForm.js
@@ -1,7 +1,6 @@
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
 
 const UploadGradeDataJobForm = ({ callback }) => {
-
   const handleSubmit = (event) => {
     event.preventDefault();
     callback();

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -143,11 +143,7 @@ const AdminJobsPage = () => {
     },
     {
       name: "Update Grade Info",
-      form: (
-        <UploadGradeDataJobForm
-          callback={submitUploadGradeDataJob}
-        />
-      ),
+      form: <UploadGradeDataJobForm callback={submitUploadGradeDataJob} />,
     },
   ];
 

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -10,6 +10,7 @@ import { useBackendMutation } from "main/utils/useBackend";
 import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
 import UpdateCoursesByQuarterJobForm from "main/components/Jobs/UpdateCoursesByQuarterJobForm";
 import UpdateCoursesByQuarterRangeJobForm from "main/components/Jobs/UpdateCoursesByQuarterRangeJobForm";
+import UploadGradeDataJobForm from "main/components/Jobs/UploadGradeDataJobForm";
 
 const AdminJobsPage = () => {
   const refreshJobsIntervalMilliseconds = 5000;
@@ -48,6 +49,12 @@ const AdminJobsPage = () => {
     method: "POST",
   });
 
+  // ***** upload grades job *******
+  const objectToAxiosParamsUploadGradeDataJob = () => ({
+    url: `/api/jobs/launch/uploadGradeData`,
+    method: "POST",
+  });
+
   // Stryker disable all
   const updateCoursesJobMutation = useBackendMutation(
     objectToAxiosParamsUpdateCoursesJob,
@@ -65,6 +72,12 @@ const AdminJobsPage = () => {
     {},
     ["/api/jobs/all"],
   );
+
+  const uploadGradeDataMutation = useBackendMutation(
+    objectToAxiosParamsUploadGradeDataJob,
+    {},
+    ["/api/jobs/all"],
+  );
   // Stryker restore all
 
   const submitUpdateCoursesJob = async (data) => {
@@ -77,6 +90,10 @@ const AdminJobsPage = () => {
 
   const submitUpdateCoursesByQuarterRangeJob = async (data) => {
     updateCoursesByQuarterRangeJobMutation.mutate(data);
+  };
+
+  const submitUploadGradeDataJob = async (data) => {
+    uploadGradeDataMutation.mutate(data);
   };
 
   // Stryker disable all
@@ -113,6 +130,10 @@ const AdminJobsPage = () => {
       ),
     },
     {
+      name: "Update Course Database by quarter range for one subject",
+      form: <JobComingSoon />,
+    },
+    {
       name: "Update Courses Database by quarter range",
       form: (
         <UpdateCoursesByQuarterRangeJobForm
@@ -122,7 +143,11 @@ const AdminJobsPage = () => {
     },
     {
       name: "Update Grade Info",
-      form: <JobComingSoon />,
+      form: (
+        <UploadGradeDataJobForm
+          callback={submitUploadGradeDataJob}
+        />
+      ),
     },
   ];
 

--- a/frontend/src/stories/components/Jobs/UploadGradeDataJobForm.stories.js
+++ b/frontend/src/stories/components/Jobs/UploadGradeDataJobForm.stories.js
@@ -1,0 +1,31 @@
+import React from "react";
+
+import UploadGradeDataJobForm from "main/components/Jobs/UploadGradeDataJobForm";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+export default {
+  title: "components/Jobs/UploadGradeDataJobForm",
+  component: UploadGradeDataJobForm,
+  parameters: {
+    mockData: [
+      {
+        url: "/api/systemInfo",
+        method: "GET",
+        status: 200,
+        response: systemInfoFixtures.showingBoth,
+      },
+    ],
+  },
+};
+
+const Template = (args) => {
+  return <UploadGradeDataJobForm {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  callback: (data) => {
+    console.log("Submit was clicked, data=", data);
+  },
+};

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -39,7 +39,7 @@ describe("AdminJobsPage tests", () => {
     expect(await screen.findByText("Launch Jobs")).toBeInTheDocument();
     expect(await screen.findByText("Job Status")).toBeInTheDocument();
 
-    ["Test Job", "Update Courses Database", "Update Grade Info"].map(
+    ["Test Job", "Update Courses Database", "Update Grade Info", "Update Course Database by quarter range for one subject"].map(
       (jobName) => expect(screen.getByText(jobName)).toBeInTheDocument(),
     );
 
@@ -219,6 +219,37 @@ describe("AdminJobsPage tests", () => {
 
     expect(axiosMock.history.post[0].url).toBe(
       "/api/jobs/launch/updateCoursesRangeOfQuarters?start_quarterYYYYQ=20212&end_quarterYYYYQ=20213",
+    );
+  });
+  test("user can submit the update grade data job", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminJobsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByText("Update Grade Info"),
+    ).toBeInTheDocument();
+
+    const updateCoursesButton = screen.getByText("Update Grade Info");
+    expect(updateCoursesButton).toBeInTheDocument();
+    updateCoursesButton.click();
+
+    expect(await screen.findByTestId("TestJobForm-fail")).toBeInTheDocument();
+
+    const submitButton = screen.getByTestId("uploadGradeData");
+
+    expect(submitButton).toBeInTheDocument();
+
+    submitButton.click();
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].url).toBe(
+      "/api/jobs/launch/uploadGradeData",
     );
   });
 });

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -39,9 +39,12 @@ describe("AdminJobsPage tests", () => {
     expect(await screen.findByText("Launch Jobs")).toBeInTheDocument();
     expect(await screen.findByText("Job Status")).toBeInTheDocument();
 
-    ["Test Job", "Update Courses Database", "Update Grade Info", "Update Course Database by quarter range for one subject"].map(
-      (jobName) => expect(screen.getByText(jobName)).toBeInTheDocument(),
-    );
+    [
+      "Test Job",
+      "Update Courses Database",
+      "Update Grade Info",
+      "Update Course Database by quarter range for one subject",
+    ].map((jobName) => expect(screen.getByText(jobName)).toBeInTheDocument());
 
     const testId = "JobsTable";
 
@@ -230,9 +233,7 @@ describe("AdminJobsPage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(
-      await screen.findByText("Update Grade Info"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Update Grade Info")).toBeInTheDocument();
 
     const updateCoursesButton = screen.getByText("Update Grade Info");
     expect(updateCoursesButton).toBeInTheDocument();


### PR DESCRIPTION
Closes #35 
Partially addresses #4 (Implements one of the jobs)

In this PR, I implemented the frontend for the Upload Grade Data admin job, replacing the "Job coming soon" placeholder. I added a button to run the job so that Swagger isn't needed to access the endpoint. I also added a test case and story file for it. In addition, I added the last unimplemented Swagger job as a placeholder. This job is Updating the Course Database by quarter range for a single course. This job has the "Job coming soon" message as a placeholder for potential future implementation.

Deployment link: https://team04-tihdir-dev.dokku-04.cs.ucsb.edu

Job takes about 20 min to complete.

<img width="1360" alt="Screen Shot 2024-05-27 at 5 00 13 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-4/assets/46095500/1bdd464a-4a9e-465c-a914-09f1cc10c868">

<img width="1372" alt="Screen Shot 2024-05-27 at 5 22 06 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-4/assets/46095500/a611d8da-3ae8-4a6e-9d8b-7694ef0277d1">


<img width="1368" alt="Screen Shot 2024-05-27 at 5 00 41 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-4/assets/46095500/5623053f-bddf-4ba7-a82a-f4d932fadd9b">

