### PR TITLE
Added Course Grade Distribution Table to Course Details Page

### DIFF
--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -55,6 +55,7 @@ export default function CourseDetailsIndexPage() {
     },
   );
 
+  // Stryker restore all
   if (gradeData === undefined) {
     gradeData = [];
   }
@@ -70,7 +71,7 @@ export default function CourseDetailsIndexPage() {
 
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}
-        {moreDetails && gradeData.length > 0 ? (
+        {moreDetails ? (
           <Fragment>
             <h5>Course Grade Distribution for {moreDetails.courseId}</h5>
             <CourseGradeDistTable gradeData={gradeData} />

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -5,6 +5,9 @@ import { useBackend, _useBackendMutation } from "main/utils/useBackend";
 import CourseDetailsTable from "main/components/CourseDetails/CourseDetailsTable";
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import CourseDescriptionTable from "main/components/Courses/CourseDescriptionTable";
+import CourseGradeDistTable from "main/components/CourseGradeDist/CourseGradeDistTable";
+import { parseCourseId } from "main/utils/CoursesUtils";
+import { Fragment } from "react";
 
 export default function CourseDetailsIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -26,9 +29,40 @@ export default function CourseDetailsIndexPage() {
     },
   );
 
+  // Parse the subject area and course number, if moreDetails undefined, just leave them blank
+  let subjectArea = "",
+    courseNumber = "";
+  if (moreDetails) {
+    ({ subjectArea, courseNumber } = parseCourseId(moreDetails.courseId));
+  }
+  // Will return grade data or an empty array if moreDetails undefined
+  let {
+    data: gradeData,
+    _error1,
+    _status1,
+  } = useBackend(
+    // Stryker disable all : hard to test for query caching
+    [
+      `/api/gradehistory/search?subjectArea=${subjectArea}&courseNumber=${courseNumber}`,
+    ],
+    {
+      method: "GET",
+      url: `/api/gradehistory/search`,
+      params: {
+        subjectArea,
+        courseNumber,
+      },
+    },
+  );
+
+  if (gradeData === undefined) {
+    gradeData = [];
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
+        <p>{`${subjectArea}+${courseNumber}`}</p>
         {moreDetails && moreDetails.courseId && (
           <h5>
             Course Details for {moreDetails.courseId} {yyyyqToQyy(qtr)}
@@ -37,6 +71,14 @@ export default function CourseDetailsIndexPage() {
 
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}
+        {moreDetails && gradeData.length > 0 ? (
+          <Fragment>
+            <h5>Course Grade Distribution for {moreDetails.courseId}</h5>
+            <CourseGradeDistTable gradeData={gradeData} />
+          </Fragment>
+        ) : (
+          <h5>No Course Grade Distribution Available</h5>
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -62,7 +62,6 @@ export default function CourseDetailsIndexPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <p>{`${subjectArea}+${courseNumber}`}</p>
         {moreDetails && moreDetails.courseId && (
           <h5>
             Course Details for {moreDetails.courseId} {yyyyqToQyy(qtr)}

--- a/frontend/src/main/utils/CoursesUtils.js
+++ b/frontend/src/main/utils/CoursesUtils.js
@@ -14,3 +14,12 @@ export function cellToAxiosParamsDelete(cell) {
     },
   };
 }
+
+// Example: courseId="CMPSC     130A     " => { subjectArea: "CMPSC", courseNumber: "130A" }
+export function parseCourseId(courseId) {
+  const splitCourseId = courseId.split(" ").filter((x) => x.length > 0);
+  return {
+    subjectArea: splitCourseId[0],
+    courseNumber: splitCourseId[1],
+  };
+}

--- a/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
@@ -101,6 +101,7 @@ describe("Course Details Index Page tests", () => {
     expect(screen.getByText("T R")).toBeInTheDocument();
     expect(screen.getByText("Time")).toBeInTheDocument();
     expect(screen.getByText("2:00 PM - 3:15 PM")).toBeInTheDocument();
+    expect(screen.getByText("Course Description")).toBeInTheDocument();
   });
 
   test("Calls Course Grade Distribution api correctly and displays correct information", async () => {
@@ -113,15 +114,23 @@ describe("Course Details Index Page tests", () => {
     );
     expect(screen.getByText("Bob Test1")).toBeInTheDocument();
     expect(screen.getByText("A-")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No Course Grade Distribution Available"),
+    ).not.toBeInTheDocument();
   });
 
-  test("Displays no grade distribution correctly", async () => {
-    const queryClient2 = new QueryClient();
+  test("Displays no data correctly", async () => {
     axiosMock
-      .onGet("/api/gradehistory/search", {
-        params: { subjectArea: "CHEM", courseNumber: "184" },
+      .onGet("/api/sections/sectionsearch", {
+        params: { qtr: "20221", enrollCode: "06619" },
       })
       .reply(200, []);
+    axiosMock
+      .onGet("/api/gradehistory/search", {
+        params: { subjectArea: "", courseNumber: "" },
+      })
+      .reply(200, []);
+    const queryClient2 = new QueryClient();
     render(
       <QueryClientProvider client={queryClient2}>
         <MemoryRouter>
@@ -129,6 +138,10 @@ describe("Course Details Index Page tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
+    expect(
+      screen.queryByText("Course Details for CHEM 184 W22"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Course Description")).not.toBeInTheDocument();
     expect(
       screen.getByText("No Course Grade Distribution Available"),
     ).toBeInTheDocument();

--- a/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { Query, QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
@@ -9,6 +9,69 @@ import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexP
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { personalSectionsFixtures } from "fixtures/personalSectionsFixtures";
+import { gradeDistFixtures } from "fixtures/courseGradeDistFixtures";
+
+// eslint-disable-next-line no-unused-vars
+const examplePersonalSectionRes = [
+  {
+    quarter: "20221",
+    courseId: "CMPSC   130B ",
+    title: "DATA STRUCT ALG II",
+    contactHours: 30.0,
+    description:
+      "Design and analysis of computer algorithms. Correctness proofs and solution of recurrence relations. Design techniques; divide and conquer, greedy str ategies, dynamic programming. Applications of techniques to problems from s everal disciplines. NP - completeness.",
+    college: "ENGR",
+    objLevelCode: "U",
+    subjectArea: "CMPSC   ",
+    unitsFixed: 4.0,
+    unitsVariableHigh: null,
+    unitsVariableLow: null,
+    delayedSectioning: null,
+    inProgressCourse: null,
+    gradingOption: "L",
+    instructionType: "LEC",
+    onLineCourse: false,
+    deptCode: "CMPSC",
+    generalEducation: [],
+    classSections: [
+      {
+        enrollCode: "08169",
+        section: "0100",
+        session: null,
+        classClosed: "Y",
+        courseCancelled: null,
+        gradingOptionCode: null,
+        enrolledTotal: 106,
+        maxEnroll: 100,
+        secondaryStatus: "R",
+        departmentApprovalRequired: false,
+        instructorApprovalRequired: false,
+        restrictionLevel: null,
+        restrictionMajor: "+CPSCI+CMPSC+CMPEN",
+        restrictionMajorPass: null,
+        restrictionMinor: null,
+        restrictionMinorPass: null,
+        concurrentCourses: [],
+        timeLocations: [
+          {
+            room: "1104",
+            building: "HFH",
+            roomCapacity: 188,
+            days: " T R   ",
+            beginTime: "11:00",
+            endTime: "12:15",
+          },
+        ],
+        instructors: [
+          {
+            instructor: "VIGODA E J",
+            functionCode: "Teaching and in charge",
+          },
+        ],
+      },
+    ],
+  },
+];
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -35,6 +98,7 @@ jest.mock("react-router-dom", () => {
     },
   };
 });
+
 describe("Course Details Index Page tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
   beforeEach(() => {
@@ -56,6 +120,11 @@ describe("Course Details Index Page tests", () => {
         params: { qtr: "20221", enrollCode: "06619" },
       })
       .reply(200, personalSectionsFixtures.singleSection);
+    axiosMock
+      .onGet("/api/gradehistory/search", {
+        params: { subjectArea: "CHEM", courseNumber: "184" },
+      })
+      .reply(200, gradeDistFixtures.threeGradeDist);
   });
 
   const queryClient = new QueryClient();
@@ -97,4 +166,98 @@ describe("Course Details Index Page tests", () => {
     expect(screen.getByText("Time")).toBeInTheDocument();
     expect(screen.getByText("2:00 PM - 3:15 PM")).toBeInTheDocument();
   });
+
+  test("Calls Course Grade Distribution api correctly and displays correct information", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseDetailsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText("Bob Test1")).toBeInTheDocument();
+    expect(screen.getByText("A-")).toBeInTheDocument();
+  });
+
+  test("Displays no grade distribution correctly", async () => {
+    const queryClient2 = new QueryClient();
+    axiosMock
+      .onGet("/api/gradehistory/search", {
+        params: { subjectArea: "CHEM", courseNumber: "184" },
+      })
+      .reply(200, []);
+    render(
+      <QueryClientProvider client={queryClient2}>
+        <MemoryRouter>
+          <CourseDetailsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(
+      screen.getByText("No Course Grade Distribution Available"),
+    ).toBeInTheDocument();
+  });
 });
+
+// describe("Course Grade Distribution Tests", () => {
+//   const axiosMock = new AxiosMockAdapter(axios);
+//   beforeEach(() => {
+//     jest.spyOn(console, "error");
+//     console.error.mockImplementation(() => null);
+//   });
+
+//   beforeEach(() => {
+//     axiosMock.reset();
+//     axiosMock.resetHistory();
+//     axiosMock
+//       .onGet("/api/currentUser")
+//       .reply(200, apiCurrentUserFixtures.userOnly);
+//     axiosMock
+//       .onGet("/api/systemInfo")
+//       .reply(200, systemInfoFixtures.showingNeither);
+//     axiosMock
+//       .onGet("/api/sections/sectionsearch", {
+//         params: { qtr: "20221", enrollCode: "06619" },
+//       })
+//       .reply(200, personalSectionsFixtures.singleSection);
+//   });
+//   test("Calls Course Grade Distribution api correctly and displays correct information", async () => {
+//     const queryClient = new QueryClient();
+
+//     axiosMock
+//       .onGet("/api/gradehistory/search", {
+//         params: { subjectArea: "CMPSC", courseNumber: "130B" },
+//       })
+//       .reply(200, gradeDistFixtures.threeGradeDist);
+//     render(
+//       <QueryClientProvider client={queryClient}>
+//         <MemoryRouter>
+//           <CourseDetailsIndexPage />
+//         </MemoryRouter>
+//       </QueryClientProvider>,
+//     );
+//     expect(screen.getByText("Bob Test1")).toBeInTheDocument();
+//     expect(screen.getByText("A-")).toBeInTheDocument();
+//     expect(screen.getByText("20232")).toBeInTheDocument();
+//   });
+
+//   test("Displays no grade distribution correctly", async () => {
+//     const queryClient = new QueryClient();
+
+//     axiosMock
+//       .onGet("/api/gradehistory/search", {
+//         params: { subjectArea: "CMPSC", courseNumber: "130B" },
+//       })
+//       .reply(200, []);
+//     render(
+//       <QueryClientProvider client={queryClient}>
+//         <MemoryRouter>
+//           <CourseDetailsIndexPage />
+//         </MemoryRouter>
+//       </QueryClientProvider>,
+//     );
+//     expect(
+//       screen.getByText("No Course Grade Distribution Available"),
+//     ).toBeInTheDocument();
+//   });
+// });

--- a/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
@@ -1,77 +1,14 @@
 import { render, screen } from "@testing-library/react";
-import { Query, QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-// import userEvent from "@testing-library/user-event";
 
 import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { personalSectionsFixtures } from "fixtures/personalSectionsFixtures";
 import { gradeDistFixtures } from "fixtures/courseGradeDistFixtures";
-
-// eslint-disable-next-line no-unused-vars
-const examplePersonalSectionRes = [
-  {
-    quarter: "20221",
-    courseId: "CMPSC   130B ",
-    title: "DATA STRUCT ALG II",
-    contactHours: 30.0,
-    description:
-      "Design and analysis of computer algorithms. Correctness proofs and solution of recurrence relations. Design techniques; divide and conquer, greedy str ategies, dynamic programming. Applications of techniques to problems from s everal disciplines. NP - completeness.",
-    college: "ENGR",
-    objLevelCode: "U",
-    subjectArea: "CMPSC   ",
-    unitsFixed: 4.0,
-    unitsVariableHigh: null,
-    unitsVariableLow: null,
-    delayedSectioning: null,
-    inProgressCourse: null,
-    gradingOption: "L",
-    instructionType: "LEC",
-    onLineCourse: false,
-    deptCode: "CMPSC",
-    generalEducation: [],
-    classSections: [
-      {
-        enrollCode: "08169",
-        section: "0100",
-        session: null,
-        classClosed: "Y",
-        courseCancelled: null,
-        gradingOptionCode: null,
-        enrolledTotal: 106,
-        maxEnroll: 100,
-        secondaryStatus: "R",
-        departmentApprovalRequired: false,
-        instructorApprovalRequired: false,
-        restrictionLevel: null,
-        restrictionMajor: "+CPSCI+CMPSC+CMPEN",
-        restrictionMajorPass: null,
-        restrictionMinor: null,
-        restrictionMinorPass: null,
-        concurrentCourses: [],
-        timeLocations: [
-          {
-            room: "1104",
-            building: "HFH",
-            roomCapacity: 188,
-            days: " T R   ",
-            beginTime: "11:00",
-            endTime: "12:15",
-          },
-        ],
-        instructors: [
-          {
-            instructor: "VIGODA E J",
-            functionCode: "Teaching and in charge",
-          },
-        ],
-      },
-    ],
-  },
-];
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -146,11 +83,10 @@ describe("Course Details Index Page tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    // await waitFor(() => {
+
     expect(
       screen.getByText("Course Details for CHEM 184 W22"),
     ).toBeInTheDocument();
-    // });
     expect(screen.getByText("Enroll Code")).toBeInTheDocument();
     expect(screen.getByText("06619")).toBeInTheDocument();
     expect(screen.getByText("Section")).toBeInTheDocument();
@@ -198,66 +134,3 @@ describe("Course Details Index Page tests", () => {
     ).toBeInTheDocument();
   });
 });
-
-// describe("Course Grade Distribution Tests", () => {
-//   const axiosMock = new AxiosMockAdapter(axios);
-//   beforeEach(() => {
-//     jest.spyOn(console, "error");
-//     console.error.mockImplementation(() => null);
-//   });
-
-//   beforeEach(() => {
-//     axiosMock.reset();
-//     axiosMock.resetHistory();
-//     axiosMock
-//       .onGet("/api/currentUser")
-//       .reply(200, apiCurrentUserFixtures.userOnly);
-//     axiosMock
-//       .onGet("/api/systemInfo")
-//       .reply(200, systemInfoFixtures.showingNeither);
-//     axiosMock
-//       .onGet("/api/sections/sectionsearch", {
-//         params: { qtr: "20221", enrollCode: "06619" },
-//       })
-//       .reply(200, personalSectionsFixtures.singleSection);
-//   });
-//   test("Calls Course Grade Distribution api correctly and displays correct information", async () => {
-//     const queryClient = new QueryClient();
-
-//     axiosMock
-//       .onGet("/api/gradehistory/search", {
-//         params: { subjectArea: "CMPSC", courseNumber: "130B" },
-//       })
-//       .reply(200, gradeDistFixtures.threeGradeDist);
-//     render(
-//       <QueryClientProvider client={queryClient}>
-//         <MemoryRouter>
-//           <CourseDetailsIndexPage />
-//         </MemoryRouter>
-//       </QueryClientProvider>,
-//     );
-//     expect(screen.getByText("Bob Test1")).toBeInTheDocument();
-//     expect(screen.getByText("A-")).toBeInTheDocument();
-//     expect(screen.getByText("20232")).toBeInTheDocument();
-//   });
-
-//   test("Displays no grade distribution correctly", async () => {
-//     const queryClient = new QueryClient();
-
-//     axiosMock
-//       .onGet("/api/gradehistory/search", {
-//         params: { subjectArea: "CMPSC", courseNumber: "130B" },
-//       })
-//       .reply(200, []);
-//     render(
-//       <QueryClientProvider client={queryClient}>
-//         <MemoryRouter>
-//           <CourseDetailsIndexPage />
-//         </MemoryRouter>
-//       </QueryClientProvider>,
-//     );
-//     expect(
-//       screen.getByText("No Course Grade Distribution Available"),
-//     ).toBeInTheDocument();
-//   });
-// });

--- a/frontend/src/tests/utils/CoursesUtils.test.js
+++ b/frontend/src/tests/utils/CoursesUtils.test.js
@@ -1,6 +1,7 @@
 import {
   onDeleteSuccess,
   cellToAxiosParamsDelete,
+  parseCourseId,
 } from "main/utils/CoursesUtils";
 import mockConsole from "jest-mock-console";
 
@@ -46,6 +47,15 @@ describe("CoursesUtils", () => {
         method: "DELETE",
         params: { id: 17 },
       });
+    });
+  });
+
+  test("parseCourseId tests", () => {
+    const courseId = "     CMPSC        130A      ";
+    const result = parseCourseId(courseId);
+    expect(result).toEqual({
+      subjectArea: "CMPSC",
+      courseNumber: "130A",
     });
   });
 });


### PR DESCRIPTION
Added the Course Grade Distribution Table to Course Details Page.
Now for some course details page: "/coursedetails/20201/22222" (random qtr/year, enrollId), a course grade distribution table with the data returned from the endpoint "/api/gradehistory?subjectArea=CMPSC&courseNumber=130A" (subjectArea and courseNumber corresponding to the enrollId) will be displayed via the CourseGradeDistTable component.

Dokku deployment: https://al-proj-courses.dokku-04.cs.ucsb.edu
Example page with grade distribution: https://al-proj-courses.dokku-04.cs.ucsb.edu/coursedetails/20221/08128