### PR TITLE
Course Search History Displays in Correct Order

### DIFF
--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -19,7 +19,7 @@ export default function CourseOverTimeIndexPage() {
   });
 
   const onSuccess = (courses) => {
-    setCourseJSON(courses);
+    setCourseJSON(courses.reverse());
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeIndexPage.test.js
@@ -93,6 +93,6 @@ describe("CourseOverTimeIndexPage tests", () => {
       courseNumber: "130A",
     });
 
-    expect(screen.getByText("ECE 1A")).toBeInTheDocument();
+    expect(screen.getByText("ECE 5")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #9 

In this PR, I fixed the bug where the course search history would display in the wrong order. Now it displays the most recent courses at the top.

<img width="1400" alt="Screen Shot 2024-05-29 at 4 50 17 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-4/assets/46095500/6cf2c217-fce5-42a9-9bb8-b6ab55141139">

